### PR TITLE
OE0-4: added lacking perms for 'product-be' module

### DIFF
--- a/product/__init__.py
+++ b/product/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'product.apps.ProductConfig'

--- a/product/apps.py
+++ b/product/apps.py
@@ -3,7 +3,11 @@ from django.apps import AppConfig
 MODULE_NAME = "product"
 
 DEFAULT_CFG = {
-    "gql_query_products_perms": []
+    "gql_query_products_perms": ['121001'],
+    "gql_mutation_products_add_perms": ['121002'],
+    "gql_mutation_products_edit_perms": ['121003'],
+    "gql_mutation_products_delete_perms": ['121004'],
+    "gql_mutation_products_duplicate_perms": ['121005'],
 }
 
 
@@ -11,10 +15,22 @@ class ProductConfig(AppConfig):
     name = MODULE_NAME
 
     gql_query_products_perms = []
+    gql_mutation_products_add_perms = []
+    gql_mutation_products_edit_perms = []
+    gql_mutation_products_delete_perms = []
+    gql_mutation_products_duplicate_perms = []
 
     def _configure_permissions(self, cfg):
         ProductConfig.gql_query_products_perms = cfg[
             "gql_query_products_perms"]
+        ProductConfig.gql_mutation_products_add_perms = cfg[
+            "gql_mutation_products_add_perms"]
+        ProductConfig.gql_mutation_products_edit_perms = cfg[
+            "gql_mutation_products_edit_perms"]
+        ProductConfig.gql_mutation_products_delete_perms = cfg[
+            "gql_mutation_products_delete_perms"]
+        ProductConfig.gql_mutation_products_duplicate_perms = cfg[
+            "gql_mutation_products_duplicate_perms"]
 
     def ready(self):
         from core.models import ModuleConfiguration


### PR DESCRIPTION
part of TICKET https://openimis.atlassian.net/browse/OE0-4

added missing perms for product module according to https://openimis.atlassian.net/wiki/spaces/OP/pages/1775173658/openIMIS+Authorities